### PR TITLE
Initial version of event_stream library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in event_stream.gemspec
+gemspec
+
+group :development, :test do
+  gem "pry"
+  gem "awesome_print"
+  gem 'm', :git => 'git@github.com:ANorwell/m.git', :branch => 'minitest_5'
+end
+
+group :test do
+  gem 'minitest_should', :git => 'git@github.com:citrus/minitest_should.git'
+end

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Datto
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Create an event subscription:
 ```ruby
 EventStream.subscribe(:my_event) do |event|
   log("#{event.name}, #{event.description}")
+end
 ```
 Then fire an event:
 
@@ -34,7 +35,7 @@ EventStream.subscribe(/my/) { |e| ... }
 EventStream.subscribe(:user_id => 1) { |e| ... }
 
 # Subscribe to events based on an arbitrary filter
-filter = lambda { |e| e.size > 3}
+filter = lambda { |e| e.size > 3 }
 EventStream.subscribe(filter) { |e| ... }
 ```
 
@@ -53,7 +54,7 @@ stream.publish(...)
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'event_stream'
+gem 'event_stream', :git => 'git@github.com:backupify/event_stream.git'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# EventStream
+
+A minimal library for synchronously publishing and subscribing to events.
+
+## Usage
+
+Create an event subscription:
+
+```ruby
+EventStream.subscribe(:my_event) do |event|
+  log("#{event.name}, #{event.description}")
+```
+Then fire an event:
+
+```ruby
+EventStream.publish(:my_event, :description => "An example event.")
+```
+
+An event is just an OpenStruct with a name and a bundle of other attributes, so the use of `:description` here is arbitrary.
+
+Events can be subscribed to by name, as above, but many other ways are supported:
+
+```ruby
+# Subscribe to all events
+EventStream.subscribe { |e| ... }
+
+# Subscribe to events with a given name
+EventStream.subscribe(:my_event) { |e| ... }
+
+# Subscribe to events based on a name regex
+EventStream.subscribe(/my/) { |e| ... }
+
+# Subscribe to events based on their attributes
+EventStream.subscribe(:user_id => 1) { |e| ... }
+
+# Subscribe to events based on an arbitrary filter
+filter = lambda { |e| e.size > 3}
+EventStream.subscribe(filter) { |e| ... }
+```
+
+### Event Streams
+
+If you wish, you may create more than one event stream:
+
+```ruby
+stream = EventStream::Stream.new
+stream.subscribe(...) { |e| ... }
+stream.publish(...)
+```
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'event_stream'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install event_stream

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+

--- a/event_stream.gemspec
+++ b/event_stream.gemspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'event_stream/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "event_stream"
+  spec.version       = EventStream::VERSION
+  spec.authors       = ["Arron Norwell"]
+  spec.email         = ["anorwell@datto.com"]
+  spec.summary       = %q{A minimal library for synchronously publishing and subscribing to events.}
+  spec.homepage      = ""
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-reporters"
+end

--- a/lib/event_stream.rb
+++ b/lib/event_stream.rb
@@ -1,0 +1,63 @@
+require 'ostruct'
+
+module EventStream
+  class << self
+    extend Forwardable
+
+    # The default event stream
+    # @return [Stream]
+    def default_stream
+      @default_stream ||= Stream.new
+    end
+
+    def_delegators :default_stream, :publish, :subscribe
+  end
+
+  # An Event. Each event is an OpenStruct with a name as well as any number of other optional fields.
+  # @!attribute name
+  #   @return [Symbol]
+  class Event < OpenStruct; end
+
+  class Stream
+    def initialize
+      @subscribers = []
+    end
+
+    # Publishes an event to this event stream
+    # @param name [Symbol] name of this event
+    # @param attrs [Hash] optional attributes representing this event
+    def publish(name, attrs = {})
+      e = Event.new(attrs.merge(:name => name))
+      @subscribers.each { |l| l.consume(e) }
+    end
+
+    # Registers a subscriber to this event stream.
+    # @param filter [Object] Filters which events this subscriber will consume.
+    # If a string or regexp is provided, these will be matched against the event name.
+    # A hash will be matched against the attributes of the event.
+    # Or, any arbitrary predicate on events may be provided.
+    # @yield [Event] action to perform when the event occurs.
+    def subscribe(filter = nil, &action)
+      filter ||= lambda { |e| true }
+      filter_predicate = case filter
+                         when Symbol, String then lambda { |e| e.name.to_s == filter.to_s }
+                         when Regexp then lambda { |e| e.name =~ filter }
+                         when Hash then lambda { |e| filter.all? { |k,v| e[k] === v } }
+                         else filter
+                         end
+      @subscribers << Subscriber.new(filter_predicate, action)
+    end
+
+    # Clears all subscribers from this event stream.
+    def clear_subscribers
+      @subscribers = []
+    end
+  end
+
+  # @private
+  class Subscriber < Struct.new(:filter, :action)
+    def consume(event)
+      action.call(event) if filter.call(event)
+    end
+  end
+end

--- a/lib/event_stream/version.rb
+++ b/lib/event_stream/version.rb
@@ -1,0 +1,3 @@
+module EventStream
+  VERSION = "0.0.1"
+end

--- a/test/event_stream_test.rb
+++ b/test/event_stream_test.rb
@@ -1,0 +1,54 @@
+require_relative 'test_helper'
+
+class EventStreamTest < Minitest::Should::TestCase
+
+  def pub_sub(name, attrs = {}, filter = nil)
+    event = nil
+    EventStream.subscribe(filter) do |e|
+      event = e
+    end
+    EventStream.publish(name, attrs)
+    event
+  end
+
+  teardown do
+    EventStream.default_stream.clear_subscribers
+  end
+
+  context 'an event stream' do
+    should 'publish an event and allow a subscriber to consume it' do
+      event = pub_sub(:test)
+      assert event
+      assert_equal :test, event.name
+    end
+
+    should 'expose all event attributes to the subscriber' do
+      event = pub_sub(:test, :x => 1)
+      assert_equal 1, event.x
+    end
+
+    context 'filtering events' do
+      should 'allow subscription to event names' do
+        assert pub_sub(:test, {}, :test)
+        refute pub_sub(:test, {}, :other_name)
+      end
+
+      should 'allow subscription to event names by regex' do
+        assert pub_sub(:test_event, {}, /test/)
+        refute pub_sub(:test_event, {}, /no_match/)
+      end
+
+      should 'allow subscription by event attributes' do
+        assert pub_sub(:test, { :x => 1, :y => :attr}, :y => :attr)
+        refute pub_sub(:test, { :x => 1, :y => :other}, :y => :attr)
+      end
+
+      should 'allow subscription via arbitrary predicate' do
+        predicate = lambda { |e| e.x > 1 }
+        assert pub_sub(:test, { :x => 2, :y => :attr}, predicate)
+        refute pub_sub(:test, { :x => 1, :y => :attr}, predicate)
+      end
+
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,13 @@
+require 'rubygems'
+require 'pry'
+require 'minitest/autorun'
+require 'minitest/should'
+
+
+require 'event_stream'
+
+class Minitest::Should::TestCase
+  def self.xshould(*args)
+    puts "Disabled test: #{args}"
+  end
+end


### PR DESCRIPTION
(Copied from readme)
# EventStream

A minimal library for synchronously publishing and subscribing to events.
## Usage

Create an event subscription:

``` ruby
EventStream.subscribe(:my_event) do |event|
  log("#{event.name}, #{event.description}")
```

Then fire an event:

``` ruby
EventStream.publish(:my_event, :description => "An example event.")
```

An event is just an OpenStruct with a name and a bundle of other attributes, so the use of `:description` here is arbitrary.

Events can be subscribed to by name, as above, but many other ways are supported:

``` ruby
# Subscribe to all events
EventStream.subscribe { |e| ... }

# Subscribe to events with a given name
EventStream.subscribe(:my_event) { |e| ... }

# Subscribe to events based on a name regex
EventStream.subscribe(/my/) { |e| ... }

# Subscribe to events based on their attributes
EventStream.subscribe(:user_id => 1) { |e| ... }

# Subscribe to events based on an arbitrary filter
filter = lambda { |e| e.size > 3}
EventStream.subscribe(filter) { |e| ... }
```
### Event Streams

If you wish, you may create more than one event stream:

``` ruby
stream = EventStream::Stream.new
stream.subscribe(...) { |e| ... }
stream.publish(...)
```
## Installation

Add this line to your application's Gemfile:

``` ruby
gem 'event_stream'
```

And then execute:

```
$ bundle
```

Or install it yourself as:

```
$ gem install event_stream
```
