### PR TITLE
Add Subscriber DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ stream.subscribe(...) { |e| ... }
 stream.publish(...)
 ```
 
+### Subscriber DSL
+
+It's sometimes useful to separate the definition of a subscriber action
+from the registration of the subscriber. The `SubscriberDSL` module
+provides a way to do this.
+
+Define a subscriber by mixing in the module:
+
+```ruby
+class MySubscriber
+  include EventStream::SubscriberDSL
+
+  # Which event_stream to use. If not specified, the default will be used.
+  event_stream EventStream.default_stream
+
+  # Sets up a subscriber using a block
+  on(:my_event) { |event| puts event.name }
+end
+```
+
+The definition of this class does NOT subscribe to any events. To subscribe
+to the :my_event event, it is necessary to call `MySubscriber.subscribe`.
+
+It is possible to use multiple `on` statements in a single class.
+`MySubscriber.subscribe` will register all subscriptions.
+
 ## Application Testing
 
 event_stream includes a test_helper module that provides some assertions, like `assert_event_published`. To use:

--- a/event_stream.gemspec
+++ b/event_stream.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
+
+  spec.add_dependency 'activesupport'
 end

--- a/lib/event_stream/subscriber_dsl.rb
+++ b/lib/event_stream/subscriber_dsl.rb
@@ -1,0 +1,49 @@
+require 'active_support/concern'
+require 'active_support/core_ext/class/attribute'
+
+module EventStream
+  # Provides a DSL with which to create Subscribers.
+  # For example:
+  #
+  #    class MySubscriber
+  #      include EventStream::SubscriberDSL
+  #
+  #      # Which event_stream to use. If not specified, the default will be used.
+  #      event_stream EventStream.default_stream
+  #
+  #      # Sets up a subscriber using a block
+  #      on(:my_other_event) { |event| puts event.name }
+  #    end
+  #
+  # Note that this does NOT register subscribers. To register subscribers, call:
+  #
+  #     MySubscriber.subscribe
+  #
+  # This registers all subscribers to the provided event_stream (or to the default).
+  #
+  module SubscriberDSL
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :_event_subscribers
+      class_attribute :_event_stream
+      attr_reader :event
+      self._event_subscribers = []
+      self._event_stream = EventStream.default_stream
+    end
+
+    module ClassMethods
+      def event_stream(event_stream)
+        self._event_stream = event_stream
+      end
+
+      def on(filter, &action)
+        self._event_subscribers << Subscriber.create(filter, &action)
+      end
+
+      def subscribe
+        _event_subscribers.each { |subscriber| _event_stream.add_subscriber(subscriber) }
+      end
+    end
+  end
+end

--- a/lib/event_stream/test_helper.rb
+++ b/lib/event_stream/test_helper.rb
@@ -9,6 +9,7 @@ module EventStream
   module Assertions
     def self.setup_test_subscription
       TestEventStream.events = []
+
       EventStream.subscribe(//) do |event|
         TestEventStream.events << event
       end

--- a/lib/event_stream/version.rb
+++ b/lib/event_stream/version.rb
@@ -1,3 +1,3 @@
 module EventStream
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/event_stream/subscriber_dsl_test.rb
+++ b/test/event_stream/subscriber_dsl_test.rb
@@ -1,0 +1,54 @@
+require_relative '../test_helper'
+
+module EventStream
+  class SubscriberDSLTest < Minitest::Should::TestCase
+
+    class MySubscriber
+      include SubscriberDSL
+
+      class << self
+        attr_accessor :events
+      end
+
+      on(:event) { |event| self.events << event  }
+
+      def a_method(event)
+        self.class.events << event
+      end
+    end
+
+    context 'The Subscriber DSL' do
+      setup do
+        MySubscriber.events = []
+      end
+
+      context 'the default stream' do
+        setup do
+          EventStream.clear_subscribers
+          MySubscriber.event_stream(EventStream.default_stream)
+          MySubscriber.subscribe
+        end
+
+        should 'handle a published event' do
+          EventStream.publish(:event, test: true)
+          assert_equal 1, MySubscriber.events.count
+        end
+      end
+
+      context 'other event streams' do
+        setup do
+          @stream = EventStream::Stream.new
+          MySubscriber.event_stream(@stream)
+
+          @stream.clear_subscribers
+          MySubscriber.subscribe
+        end
+
+        should 'handle a published event' do
+          @stream.publish(:event, test: true)
+          assert_equal 1, MySubscriber.events.count
+        end
+      end
+    end
+  end
+end

--- a/test/event_stream/test_helper_test.rb
+++ b/test/event_stream/test_helper_test.rb
@@ -6,6 +6,7 @@ module EventStream
     include Assertions
 
     setup do
+      EventStream.clear_subscribers
       Assertions.setup_test_subscription
     end
 
@@ -20,6 +21,12 @@ module EventStream
       end
     end
 
+    context 'registering the test subscription' do
+      should 'not register multiple subscriptions' do
+        assert_equal 1, EventStream.default_stream.subscribers.length
+      end
+    end
+
     context '#find_published_event' do
       should 'find an event if one is present' do
         EventStream.publish(:test_event, key: :val)
@@ -30,7 +37,6 @@ module EventStream
         EventStream.publish(:test_event, key: :other)
         refute find_published_event { |evt| evt.key == :val }
       end
-
     end
   end
 end


### PR DESCRIPTION
It's sometimes useful to separate the definition of a subscriber action
from the registration of the subscriber. The `SubscriberDSL` module
provides a way to do this.

Define a subscriber by mixing in the module:

``` ruby
class MySubscriber
  include EventStream::SubscriberDSL

  # Which event_stream to use. If not specified, the default will be used.
  event_stream EventStream.default_stream

  # Sets up a subscriber using a block
  on(:my_event) { |event| puts event.name }
end
```

The definition of this class does NOT subscribe to any events. To subscribe
to the :my_event event, it is necessary to call `MySubscriber.subscribe`.

It is possible to use multiple `on` statements in a single class.
`MySubscriber.subscribe` will register all subscriptions.
