### PR TITLE
Adds a stream registry for managing multiple event streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ stream.subscribe(...) { |e| ... }
 stream.publish(...)
 ```
 
+### The Stream Registry
+
+To allow for easy access to different streams from different call points, a registry is available for storing and
+retrieving streams. To register a stream:
+
+```ruby
+stream = EventStream::Stream.new
+EventStream.register_stream(:my_stream_name)
+```
+
+To access the stream from the registry and publish an event:
+
+```ruby
+EventStream[:my_stream_name].publish(...)
+```
+
 ### Subscriber DSL
 
 It's sometimes useful to separate the definition of a subscriber action

--- a/lib/event_stream/event.rb
+++ b/lib/event_stream/event.rb
@@ -1,0 +1,6 @@
+module EventStream
+  # An Event. Each event is an OpenStruct with a name as well as any number of other optional fields.
+  # @!attribute name
+  # @return [Symbol]
+  class Event < OpenStruct; end
+end

--- a/lib/event_stream/registry.rb
+++ b/lib/event_stream/registry.rb
@@ -1,0 +1,19 @@
+require 'active_support/core_ext/class/attribute'
+
+module EventStream
+  class Registry
+
+    class UnregisteredStream < StandardError; end
+
+    class_attribute :streams
+    self.streams = { default: Stream.new }
+
+    def self.register(stream_name, stream)
+      streams[stream_name] = stream
+    end
+
+    def self.lookup(stream_name)
+      streams[stream_name] || (raise UnregisteredStream)
+    end
+  end
+end

--- a/lib/event_stream/stream.rb
+++ b/lib/event_stream/stream.rb
@@ -1,0 +1,42 @@
+module EventStream
+  class Stream
+    def initialize
+      @subscribers = []
+    end
+
+    # Publishes an event to this event stream
+    # @param name [Symbol] name of this event
+    # @param attrs [Hash] optional attributes representing this event
+    def publish(name, attrs = {})
+      e = Event.new(attrs.merge(:name => name))
+      @subscribers.each { |l| l.consume(e) }
+    end
+
+    # Registers a subscriber to this event stream.
+    # @param filter [Object] Filters which events this subscriber will consume.
+    # If a string or regexp is provided, these will be matched against the event name.
+    # A hash will be matched against the attributes of the event.
+    # Or, any arbitrary predicate on events may be provided.
+    # @yield [Event] action to perform when the event occurs.
+    def subscribe(filter = nil, &action)
+      add_subscriber(Subscriber.create(filter, &action))
+    end
+
+    # Clears all subscribers from this event stream.
+    def clear_subscribers
+      @subscribers = []
+    end
+
+    # Returns all subscribers for this stream
+    # @return [Array<EventStream::Subscriber]
+    def subscribers
+      @subscribers
+    end
+
+    # Adds a subscriber to this stream
+    # @param [EventStream::Subscriber]
+    def add_subscriber(subscriber)
+      @subscribers << subscriber
+    end
+  end
+end

--- a/lib/event_stream/subscriber.rb
+++ b/lib/event_stream/subscriber.rb
@@ -1,0 +1,18 @@
+module EventStream
+  class Subscriber < Struct.new(:filter, :action)
+    def self.create(filter = nil, &action)
+      filter ||= lambda { |e| true }
+      filter_predicate = case filter
+                         when Symbol, String then lambda { |e| e.name.to_s == filter.to_s }
+                         when Regexp then lambda { |e| e.name =~ filter }
+                         when Hash then lambda { |e| filter.all? { |k,v| e[k] === v } }
+                         else filter
+                         end
+      new(filter_predicate, action)
+    end
+
+    def consume(event)
+      action.call(event) if filter.call(event)
+    end
+  end
+end

--- a/lib/event_stream/version.rb
+++ b/lib/event_stream/version.rb
@@ -1,3 +1,3 @@
 module EventStream
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/event_stream/event_stream_test.rb
+++ b/test/event_stream/event_stream_test.rb
@@ -51,4 +51,32 @@ class EventStreamTest < Minitest::Should::TestCase
 
     end
   end
+
+  context 'managing multiple event streams' do
+    setup do
+      @stream = EventStream::Stream.new
+      EventStream.register_stream(:test_stream, @stream)
+    end
+
+    should 'allow streams to be registered and retrieved' do
+      assert_equal @stream, EventStream[:test_stream]
+    end
+
+    should 'allow separate publishes and subscriptions to different streams' do
+      test_event = nil
+
+      EventStream[:test_stream].subscribe(//) do |e|
+        test_event = e
+      end
+
+      EventStream[:test_stream].publish(:test_event)
+      assert test_event, "Event was expected to be published to the test stream"
+      assert_equal test_event.name, :test_event
+
+      test_event = nil
+
+      EventStream.publish(:test_event)
+      refute test_event, "No event should have been published to the test stream"
+    end
+  end
 end


### PR DESCRIPTION
Provides the `EventStream[:stream_name]` interface for accessing streams
that have been registered via `EventStream.register_stream(:stream_name, stream)`.
